### PR TITLE
Potential fix for code scanning alert no. 2: Regular expression injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@actions/core": "1.11.1",
         "@actions/github": "6.0.0",
-        "jira-client": "8.2.2"
+        "jira-client": "8.2.2",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@eslint/js": "^9.20.0",
@@ -5110,6 +5111,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10184,6 +10190,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@octokit/plugin-rest-endpoint-methods": "13.3.1",
         "@types/jest": "29.5.14",
         "@types/jira-client": "7.1.9",
+        "@types/lodash": "^4.17.16",
         "@types/node": "22.13.1",
         "@vercel/ncc": "0.38.3",
         "eslint": "^9.20.0",
@@ -1975,6 +1976,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.13.1",
@@ -7971,6 +7978,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@octokit/plugin-rest-endpoint-methods": "13.3.1",
     "@types/jest": "29.5.14",
     "@types/jira-client": "7.1.9",
+    "@types/lodash": "^4.17.16",
     "@types/node": "22.13.1",
     "@vercel/ncc": "0.38.3",
     "eslint": "^9.20.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.0",
-    "jira-client": "8.2.2"
+    "jira-client": "8.2.2",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/src/estimate.ts
+++ b/src/estimate.ts
@@ -3,6 +3,7 @@ import {AutoLink, EstimateContext, Issue, LabelInterface} from './types'
 import {GitHub} from '@actions/github/lib/utils'
 import * as github from '@actions/github'
 import JiraApi from 'jira-client'
+import * as _ from 'lodash'
 
 export function getGithubClient(): InstanceType<typeof GitHub> {
   const token = process.env['GITHUB_TOKEN']
@@ -57,7 +58,8 @@ export async function findIssueKeyIn(
   )
 
   if (config.jiraProjectRegexPattern && config.jiraProjectRegexPattern !== '') {
-    searchPatterns.push(config.jiraProjectRegexPattern)
+    const safePattern = _.escapeRegExp(config.jiraProjectRegexPattern)
+    searchPatterns.push(safePattern)
   }
   core.debug(`Searching for ${JSON.stringify(searchPatterns)}`)
   for (const pattern of searchPatterns) {


### PR DESCRIPTION
Potential fix for [https://github.com/MichaelSp/jira-estimates/security/code-scanning/2](https://github.com/MichaelSp/jira-estimates/security/code-scanning/2)

To fix the problem, we need to sanitize the user input before using it to construct a regular expression. The best way to do this is by using the `_.escapeRegExp` function from the lodash library, which escapes special characters in the input string that have special meaning in regular expressions. This ensures that the user input cannot alter the intended behavior of the regular expression.

We will need to:
1. Import the lodash library in `src/estimate.ts`.
2. Use the `_.escapeRegExp` function to sanitize the `config.jiraProjectRegexPattern` before adding it to the `searchPatterns` array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
